### PR TITLE
Fix estimated time validation

### DIFF
--- a/templates/5520.html
+++ b/templates/5520.html
@@ -154,7 +154,15 @@ document.addEventListener('DOMContentLoaded', function() {
         const remote = document.getElementById('remote').value;
         const cores = document.getElementById('cores').value;
         const gpu = document.getElementById('gpu').value;
-        
+        const estimated = document.getElementById('estimated_time').value.trim();
+
+        // 验证预计使用时间格式是否为时间段
+        const rangePattern = /^\d{4}[.\/\-]\d{1,2}[.\/\-]\d{1,2}\s*[~\-\u5230\u81f3]\s*(?:\d{4}[.\/\-])?\d{1,2}[.\/\-]\d{1,2}$/;
+        if (!rangePattern.test(estimated)) {
+            alert('预计使用时间格式不正确，请输入时间段，例如: 2025.6.17~2025.6.19');
+            return;
+        }
+
         // 获取当前资源状态进行验证
         fetch('/api/resources')
             .then(response => response.json())

--- a/templates/9755.html
+++ b/templates/9755.html
@@ -156,7 +156,15 @@ document.addEventListener('DOMContentLoaded', function() {
         const remote = document.getElementById('remote').value;
         const nodes = document.getElementById('nodes').value;
         const gpu = document.getElementById('gpu').value;
-        
+        const estimated = document.getElementById('estimated_time').value.trim();
+
+        // 验证预计使用时间格式是否为时间段
+        const rangePattern = /^\d{4}[.\/\-]\d{1,2}[.\/\-]\d{1,2}\s*[~\-\u5230\u81f3]\s*(?:\d{4}[.\/\-])?\d{1,2}[.\/\-]\d{1,2}$/;
+        if (!rangePattern.test(estimated)) {
+            alert('预计使用时间格式不正确，请输入时间段，例如: 2025.6.17~2025.6.19');
+            return;
+        }
+
         // 获取当前资源状态进行验证
         fetch('/api/resources')
             .then(response => response.json())


### PR DESCRIPTION
## Summary
- require estimated time input to be a date range when adding records
- alert user if the format is invalid so single dates cannot be submitted

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68510d5d38d08326aa0bcda851d8adad